### PR TITLE
Support marking everything as down if a file exists

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -297,6 +297,16 @@ async fn main() {
                 .takes_value(true),
         )
         .arg(
+            Arg::with_name("global_down_file")
+                .short("G")
+                .long("global-down-file")
+                .env("GLOBAL_DOWN_FILE")
+                .value_name("PATH")
+                .help("Filename which, if it exists, will have all services return 'down'")
+                .required(false)
+                .takes_value(true),
+        )
+        .arg(
             Arg::with_name("db_path")
                 .short("d")
                 .long("db-path")
@@ -323,8 +333,11 @@ async fn main() {
     init_logging();
 
     let state = Arc::new(
-        UpDownState::try_new(matches.value_of("db_path").unwrap())
-            .expect("Could not initialize state database"),
+        UpDownState::try_new(
+            matches.value_of("db_path").unwrap(),
+            matches.value_of("global_down_file"),
+        )
+        .expect("Could not initialize state database"),
     );
 
     let port: u16 = matches


### PR DESCRIPTION
As part of our init refactor, I'd like to have everything `hadown` until after init finishes. This is racy if I try to do it via the control socket. This adds a simple argument of a filename which, if it exists, will make `haupdown` mark everything as down. This file can be created prior to starting `haupdown` so that we are race-free.