### PR TITLE
upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ readme = "README.md"
 repository = "https://github.com/EasyPost/haupdown"
 
 [dependencies]
-tokio = { version = "0.2", features = ["full"] }
+tokio = { version = "1.0", features = ["full"] }
 clap = "2"
-rusqlite = "0.21"
+rusqlite = "^0.24"
 log = "0.4"
 env_logger = "0.7"
 syslog = "5"
@@ -22,4 +22,4 @@ serde_json = "1"
 serde = "1"
 
 [dev-dependencies]
-tempdir = "0.3"
+tempfile = "3"

--- a/src/state.rs
+++ b/src/state.rs
@@ -238,7 +238,10 @@ mod tests {
 
     #[test]
     fn test_state_inner_basic() {
-        let dir = tempdir::TempDir::new("haupdown-test").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("haupdown-test")
+            .tempdir()
+            .unwrap();
         let db_path = dir.path().join("db.sqlite");
         let mut state = UpDownStateInner::try_new(&db_path, None).unwrap();
         let username = "some-user".to_string();
@@ -276,7 +279,10 @@ mod tests {
 
     #[test]
     fn test_global_down_path() {
-        let dir = tempdir::TempDir::new("haupdown-test").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("haupdown-test")
+            .tempdir()
+            .unwrap();
         let db_path = dir.path().join("db.sqlite");
         let global_path = dir.path().join("global_updown").into_boxed_path();
         let state = UpDownStateInner::try_new(&db_path, Some(global_path.clone())).unwrap();


### PR DESCRIPTION
Changes:

 - tokio -> 1.0
 - tempdir replaced by tempfile
 - bump rusqlite for [RUSTSEC-2020-0014](https://rustsec.org/advisories/RUSTSEC-2020-0014.html)

`cargo audit` is now clean